### PR TITLE
Fix plugin not loading on Linux due to folder captialization

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,31 +112,31 @@ jobs:
           path: ./download
 
       - run: |
-          mkdir ./build/XA-snow
-          mkdir ./build/XA-snow/win_x64
-          mkdir ./build/XA-snow/lin_x64
-          mkdir ./build/XA-snow/mac_x64
+          mkdir ./build/xa-snow
+          mkdir ./build/xa-snow/win_x64
+          mkdir ./build/xa-snow/lin_x64
+          mkdir ./build/xa-snow/mac_x64
           cp ./download/*/*.xpl ./build/.
-          mv ./build/mac.xpl ./build/XA-snow/mac_x64/xa-snow.xpl
-          mv ./build/lin.xpl ./build/XA-snow/lin_x64/xa-snow.xpl
-          mv ./build/win.xpl ./build/XA-snow/win_x64/xa-snow.xpl
-          ls -lR ./build/XA-snow
+          mv ./build/mac.xpl ./build/xa-snow/mac_x64/xa-snow.xpl
+          mv ./build/lin.xpl ./build/xa-snow/lin_x64/xa-snow.xpl
+          mv ./build/win.xpl ./build/xa-snow/win_x64/xa-snow.xpl
+          ls -lR ./build/xa-snow
 
       - run: |
-          cp -r bin ${{ github.workspace }}/build/XA-snow/
+          cp -r bin ${{ github.workspace }}/build/xa-snow/
           TAG=${GITHUB_REF##*/}
-          cp ${{ github.workspace }}/skunkcrafts_updater.cfg ${{ github.workspace }}/build/XA-snow/
-          cp ${{ github.workspace }}/skunkcrafts_updater_beta.cfg ${{ github.workspace }}/build/XA-snow/
-          cp ${{ github.workspace }}/skunkcrafts_updater_blacklist.txt ${{ github.workspace }}/build/XA-snow/
-          cp ${{ github.workspace }}/LICENSE* ${{ github.workspace }}/build/XA-snow/
-          cp ${{ github.workspace }}/ESA-license.txt ${{ github.workspace }}/build/XA-snow/
-          cp ${{ github.workspace }}/ESACCI-LC-L4-WB-Ocean-Map-150m-P13Y-2000-v4.0.png ${{ github.workspace }}/build/XA-snow/
-          sed -i '' "s/REPLACE_ME/${TAG}/g" ${{ github.workspace }}/build/XA-snow/skunkcrafts_updater.cfg
-          sed -i '' "s/REPLACE_ME/${TAG}/g" ${{ github.workspace }}/build/XA-snow/skunkcrafts_updater_beta.cfg
+          cp ${{ github.workspace }}/skunkcrafts_updater.cfg ${{ github.workspace }}/build/xa-snow/
+          cp ${{ github.workspace }}/skunkcrafts_updater_beta.cfg ${{ github.workspace }}/build/xa-snow/
+          cp ${{ github.workspace }}/skunkcrafts_updater_blacklist.txt ${{ github.workspace }}/build/xa-snow/
+          cp ${{ github.workspace }}/LICENSE* ${{ github.workspace }}/build/xa-snow/
+          cp ${{ github.workspace }}/ESA-license.txt ${{ github.workspace }}/build/xa-snow/
+          cp ${{ github.workspace }}/ESACCI-LC-L4-WB-Ocean-Map-150m-P13Y-2000-v4.0.png ${{ github.workspace }}/build/xa-snow/
+          sed -i '' "s/REPLACE_ME/${TAG}/g" ${{ github.workspace }}/build/xa-snow/skunkcrafts_updater.cfg
+          sed -i '' "s/REPLACE_ME/${TAG}/g" ${{ github.workspace }}/build/xa-snow/skunkcrafts_updater_beta.cfg
           root=$(pwd)
-          cd ${{ github.workspace }}/build/ && zip -r xa-snow.zip XA-snow && cd $root
+          cd ${{ github.workspace }}/build/ && zip -r xa-snow.zip xa-snow && cd $root
       - run: |
-          cp -r ${{ github.workspace }}/build/XA-snow/ release/
+          cp -r ${{ github.workspace }}/build/xa-snow/ release/
 
           # create crc32 checksum for all values and write to skunkcrafts_updater_whitelist.txt
           # format is <filename>|<crc32 checksum>

--- a/Makefile.mgw64
+++ b/Makefile.mgw64
@@ -44,7 +44,7 @@ XPL_DIR=/e/X-Plane-12-test
 
 $(TARGET): $(OBJECTS)
 	$(LD) -o $(TARGET) $(OBJECTS) $(LIBS) $(LDFLAGS)
-	if [ -d $(XPL_DIR)/Resources/plugins/XA-snow/win_x64 ]; then cp -p build/win.xpl $(XPL_DIR)/Resources/plugins/XA-snow/win_x64/xa-snow.xpl; fi
+	if [ -d $(XPL_DIR)/Resources/plugins/xa-snow/win_x64 ]; then cp -p build/win.xpl $(XPL_DIR)/Resources/plugins/xa-snow/win_x64/xa-snow.xpl; fi
 
 grib_test.exe: grib_test.cpp ../xplib/log_msg.cpp $(GRIB_TEST_OBJS)
 	$(CXX) $(CXXFLAGS) -DLOCAL_DEBUGSTRING -o $@ grib_test.cpp ../xplib/log_msg.cpp $(GRIB_TEST_OBJS) -lwinhttp -lz

--- a/xa-snow.cpp
+++ b/xa-snow.cpp
@@ -337,7 +337,7 @@ PLUGIN_API int XPluginStart(char* out_name, char* out_sig, char* out_desc) {
     char buffer[2048];
     XPLMGetSystemPath(buffer);
     xp_dir = std::string(buffer);  // has trailing slash
-    plugin_dir = xp_dir + "Resources/plugins/XA-snow";
+    plugin_dir = xp_dir + "Resources/plugins/xa-snow";
     output_dir = xp_dir + "Output/snow";
     pref_path = xp_dir + "Output/preferences/xa-snow.prf";
     std::filesystem::create_directory(output_dir);


### PR DESCRIPTION
As of `v2.2.0`, specifically in 931686b2e64bc53c0d734581c1605af129fe55dc, the plugin layout was updated to match XPLM 3.0's plugin layout.

However, I noticed that the plugin was not loading for me after this update. I've noticed in the past that X-Plane on Linux seems to be very strict with plugin.xpl and folder names - not only do they have to be spelled the same, they must also have the same capitalization.

I noticed that the plugin folder was capitalized as `XA-snow`, while the plugin file itself was capitalized as `xa-snow.xpl`. This pull request updates the GitHub action workflow (and all other references to this capitalized version) to use the lowercased version, which allows the plugin to be loaded on Linux.

(Theoretically, changing the output name to `XA-snow.xpl` would've also worked, but I chose the lowercase version as it appears to be the preferred capitalization in the README)

This fix was tested on Fedora 43 with X-Plane 12.4.0-b1. (I do not know if other distributions are affected, but I am assuming they are)